### PR TITLE
added modifier keywords support for mirah parser

### DIFF
--- a/src/mirah/impl/MirahLexer.java
+++ b/src/mirah/impl/MirahLexer.java
@@ -14,17 +14,17 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 */
-package mirahparser.impl;
+package mirah.impl;
+
+import mirahparser.impl.Tokens;
+import mmeta.BaseParser;
+import mmeta.BaseParser.Token;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.LinkedList;
 import java.util.ListIterator;
 import java.util.logging.Logger;
-
-import mmeta.BaseParser;
-import mmeta.BaseParser.Token;
-
 public class MirahLexer {
 
   private static final Logger logger = Logger.getLogger(MirahLexer.class.getName());
@@ -405,7 +405,7 @@ public class MirahLexer {
   }
 
   private static class StandardLexer implements Lexer {
-    @Override
+
     public Tokens lex(MirahLexer l, Input i) {
       Tokens type = processFirstChar(l, i);
       type = checkKeyword(type, i);
@@ -523,9 +523,7 @@ public class MirahLexer {
         }
         break;
       case 'a':
-        if (i.consume("bstract")) {
-          type = Tokens.tACC_ABSTRACT;
-        } else if (i.consume("lias")) {
+        if (i.consume("lias")) {
           type = Tokens.tAlias;
         } else if (i.consume("nd")) {
           type = Tokens.tAnd;
@@ -554,8 +552,6 @@ public class MirahLexer {
       case 'd':
         if (i.consume("efined")) {
           type = Tokens.tDefined;
-        } else if (i.consume("efault")) {
-	      type = Tokens.tACC_DEFAULT;
         } else if (i.consume("efmacro")) {
           type = Tokens.tDefmacro;
         } else if (i.consume("ef")) {
@@ -582,8 +578,6 @@ public class MirahLexer {
       case 'f':
         if (i.consume("alse")) {
           type = Tokens.tFalse;
-        } else if (i.consume("inal")) {
-          type = Tokens.tACC_FINAL;
         } else if (i.consume("or")) {
           type = Tokens.tFor;
         } else {
@@ -617,8 +611,6 @@ public class MirahLexer {
       case 'n':
         if (i.consume("ext")) {
           type = Tokens.tNext;
-        } else if (i.consume("ative")) {
-          type = Tokens.tACC_NATIVE;
         } else if (i.consume("il")) {
           type = Tokens.tNil;
         } else if (i.consume("ot")) {
@@ -637,12 +629,6 @@ public class MirahLexer {
       case 'p':
         if (i.consume("ackage")) {
           type = Tokens.tPackage;
-        } else if (i.consume("rivate")) {
-          type = Tokens.tACC_PRIVATE;
-        } else if (i.consume("rotected")) {
-          type = Tokens.tACC_PROTECTED;
-        }else if (i.consume("ublic")) {
-          type = Tokens.tACC_PUBLIC;
         } else {
           type = Tokens.tIDENTIFIER;
         }
@@ -674,9 +660,7 @@ public class MirahLexer {
       case 't':
         if (i.consume("hen")) {
           type = Tokens.tThen;
-        } else if (i.consume("ransient")) {
-          type = Tokens.tACC_TRANSIENT;
-        }else if (i.consume("rue")) {
+        } else if (i.consume("rue")) {
           type = Tokens.tTrue;
         } else {
           type = Tokens.tIDENTIFIER;
@@ -689,13 +673,6 @@ public class MirahLexer {
           type = Tokens.tUnless;
         } else if (i.consume("ntil")) {
           type = Tokens.tUntil;
-        } else {
-          type = Tokens.tIDENTIFIER;
-        }
-        break;
-      case 'v':
-        if (i.consume("olatile")) {
-          type = Tokens.tACC_VOLATILE;
         } else {
           type = Tokens.tIDENTIFIER;
         }
@@ -787,11 +764,7 @@ public class MirahLexer {
         break;
       case '!':
         if (i.consume('=')) {
-          if (i.consume('=')) {
-            type = Tokens.tNEE;
-          } else {
-            type = Tokens.tNE;
-          }
+          type = Tokens.tNE;
         } else if (i.consume('~')) {
           type = Tokens.tNMatch;
         } else {
@@ -1286,13 +1259,8 @@ public class MirahLexer {
     isEND = endTokens.contains(type);
     return type;
   }
-  
 
   public Token<Tokens> lex(int pos) {
-    return lex(pos, true);
-  }
-
-  public Token<Tokens> lex(int pos, boolean skipWhitespaceAndComments) {
     if (pos < input.pos()) {
       ListIterator<Token<Tokens>> it = tokens.listIterator(tokens.size());
       while (it.hasPrevious()) {
@@ -1309,14 +1277,9 @@ public class MirahLexer {
     }
     Tokens type = Tokens.tWhitespace;
     int start = input.pos();
-    if (skipWhitespaceAndComments) {
-        while (type.ordinal() > Tokens.tEOF.ordinal()) {
-          start = input.pos();
-          type = simpleLex();
-        }
-    } else {
-        start = input.pos();
-        type = simpleLex();
+    while (type.ordinal() > Tokens.tEOF.ordinal()) {
+      start = input.pos();
+      type = simpleLex();
     }
     parser._pos = input.pos();
     Token<Tokens> token = parser.build_token(type, pos, start);

--- a/src/mirah/lang/ast/ast.mirah
+++ b/src/mirah/lang/ast/ast.mirah
@@ -83,6 +83,10 @@ interface Annotated < Node do
   # end
 end
 
+interface HasModifiers < Node do
+  def modifiers:ModifierList;end
+end
+
 # Should this go somewhere else?
 # Should this support multi-dimensional arrays?
 interface TypeRef < TypeName do

--- a/src/mirah/lang/ast/klass.mirah
+++ b/src/mirah/lang/ast/klass.mirah
@@ -26,12 +26,13 @@ class ClosureDefinition < ClassDefinition
 end
 
 class FieldDeclaration < NodeImpl
-  implements Annotated, Named
+  implements Annotated, Named, HasModifiers
   init_node do
     child name: Identifier
     child type: TypeName
     child_list annotations: Annotation
     attr_accessor isStatic: 'boolean'
+    child_list modifiers: Modifier
   end
 end
 

--- a/src/mirah/lang/ast/klass.mirah
+++ b/src/mirah/lang/ast/klass.mirah
@@ -13,15 +13,56 @@ class ClassDefinition < NodeImpl
     child_list annotations: Annotation
     child_list modifiers: Modifier
   end
+
+  def initialize(pos: Position, name: Identifier, superclass: TypeName,  body: NodeList, interfaces: TypeNameList,  annotations: AnnotationList)
+    super()
+    position_set pos
+    name_set name
+    superclass_set superclass
+    interfaces_set interfaces
+    body_set body
+    annotations_set annotations
+    modifiers_set nil
+  end
+
+  def initialize(name: Identifier, superclass: TypeName,  body: NodeList, interfaces: TypeNameList,  annotations: AnnotationList)
+      super()
+      name_set name
+      superclass_set superclass
+      interfaces_set interfaces
+      body_set body
+      annotations_set annotations
+      modifiers_set nil
+    end
 end
 
 class InterfaceDeclaration < ClassDefinition
   init_subclass(ClassDefinition)
+
+  # compatibility constructor
+  def initialize(pos: Position, name: Identifier, superclass: TypeName,  body: NodeList, interfaces: TypeNameList,  annotations: AnnotationList)
+    super(pos, name, superclass, body, interfaces, annotations)
+  end
+
+  # compatibility constructor
+  def initialize(name: Identifier, superclass: TypeName,  body: NodeList, interfaces: TypeNameList,  annotations: AnnotationList)
+    super(name, superclass, body, interfaces, annotations)
+  end
 end
 
 # Is this necessary?
 class ClosureDefinition < ClassDefinition
   init_subclass(ClassDefinition)
+
+  # compatibility constructor
+  def initialize(pos: Position, name: Identifier, superclass: TypeName,  body: NodeList, interfaces: TypeNameList,  annotations: AnnotationList)
+    super(pos, name, superclass, body, interfaces, annotations)
+  end
+
+  # compatibility constructor
+  def initialize(name: Identifier, superclass: TypeName,  body: NodeList, interfaces: TypeNameList,  annotations: AnnotationList)
+    super(name, superclass, body, interfaces, annotations)
+  end
 end
 
 class FieldDeclaration < NodeImpl

--- a/src/mirah/lang/ast/klass.mirah
+++ b/src/mirah/lang/ast/klass.mirah
@@ -11,6 +11,7 @@ class ClassDefinition < NodeImpl
     child_list body: Node
     child_list interfaces: TypeName
     child_list annotations: Annotation
+    child_list modifiers: Modifier
   end
 end
 

--- a/src/mirah/lang/ast/klass.mirah
+++ b/src/mirah/lang/ast/klass.mirah
@@ -36,18 +36,26 @@ class FieldDeclaration < NodeImpl
 end
 
 class FieldAssign < NodeImpl
-  implements Annotated, Named, Assignment
+  implements Annotated, Named, Assignment, HasModifiers
   init_node do
     child name: Identifier
     child value: Node
     child_list annotations: Annotation
     attr_accessor isStatic: 'boolean'
+    child_list modifiers: Modifier
+  end
+
+  def initialize(position:Position, name:Identifier, annotations:List, isStatic:boolean, modifiers: List)
+    initialize(position, name, Node(nil), annotations, modifiers)
+    self.isStatic = isStatic
   end
 
   def initialize(position:Position, name:Identifier, annotations:List, isStatic:boolean)
-    initialize(position, name, Node(nil), annotations)
+    initialize(position, name, Node(nil), annotations, nil)
     self.isStatic = isStatic
   end
+
+
 end
 
 class FieldAccess < NodeImpl
@@ -92,11 +100,12 @@ class Colon3 < Constant
 end
 
 class ConstantAssign < NodeImpl
-  implements Annotated, Named, Assignment
+  implements Annotated, Named, Assignment, HasModifiers
   init_node do
     child name: Identifier
     child value: Node
     child_list annotations: Annotation
+    child_list modifiers: Modifier
   end
 end
 

--- a/src/mirah/lang/ast/klass.mirah
+++ b/src/mirah/lang/ast/klass.mirah
@@ -4,7 +4,7 @@ import java.util.List
 
 # Note: com.sun.source.tree uses the same node for classes, interfaces, annotations, etc.
 class ClassDefinition < NodeImpl
-  implements Annotated, Named
+  implements Annotated, Named, HasModifiers
   init_node do
     child name: Identifier
     child superclass: TypeName
@@ -14,55 +14,15 @@ class ClassDefinition < NodeImpl
     child_list modifiers: Modifier
   end
 
-  def initialize(pos: Position, name: Identifier, superclass: TypeName,  body: NodeList, interfaces: TypeNameList,  annotations: AnnotationList)
-    super()
-    position_set pos
-    name_set name
-    superclass_set superclass
-    interfaces_set interfaces
-    body_set body
-    annotations_set annotations
-    modifiers_set nil
-  end
-
-  def initialize(name: Identifier, superclass: TypeName,  body: NodeList, interfaces: TypeNameList,  annotations: AnnotationList)
-      super()
-      name_set name
-      superclass_set superclass
-      interfaces_set interfaces
-      body_set body
-      annotations_set annotations
-      modifiers_set nil
-    end
 end
 
 class InterfaceDeclaration < ClassDefinition
   init_subclass(ClassDefinition)
-
-  # compatibility constructor
-  def initialize(pos: Position, name: Identifier, superclass: TypeName,  body: NodeList, interfaces: TypeNameList,  annotations: AnnotationList)
-    super(pos, name, superclass, body, interfaces, annotations)
-  end
-
-  # compatibility constructor
-  def initialize(name: Identifier, superclass: TypeName,  body: NodeList, interfaces: TypeNameList,  annotations: AnnotationList)
-    super(name, superclass, body, interfaces, annotations)
-  end
 end
 
 # Is this necessary?
 class ClosureDefinition < ClassDefinition
   init_subclass(ClassDefinition)
-
-  # compatibility constructor
-  def initialize(pos: Position, name: Identifier, superclass: TypeName,  body: NodeList, interfaces: TypeNameList,  annotations: AnnotationList)
-    super(pos, name, superclass, body, interfaces, annotations)
-  end
-
-  # compatibility constructor
-  def initialize(name: Identifier, superclass: TypeName,  body: NodeList, interfaces: TypeNameList,  annotations: AnnotationList)
-    super(name, superclass, body, interfaces, annotations)
-  end
 end
 
 class FieldDeclaration < NodeImpl

--- a/src/mirah/lang/ast/lists.mirah
+++ b/src/mirah/lang/ast/lists.mirah
@@ -31,3 +31,7 @@ end
 class OptionalArgumentList < NodeImpl
   init_list OptionalArgument
 end
+
+class ModifierList < NodeImpl
+  init_list Modifier
+end

--- a/src/mirah/lang/ast/method.mirah
+++ b/src/mirah/lang/ast/method.mirah
@@ -87,12 +87,38 @@ class MethodDefinition < NodeImpl
     child_list modifiers: Modifier
     # exceptions
   end
+
+  # compatibility constructor
+
+  def initialize(pos: Position, name: Identifier, arguments: Arguments, type: TypeName, body: NodeList, annotations: AnnotationList)
+     super()
+     position_set pos
+     name_set name
+     arguments_set arguments
+     type_set type
+     body_set body
+     annotations_set annotations
+     modifiers_set nil
+  end
+
 end
 
 class StaticMethodDefinition < MethodDefinition
   init_subclass(MethodDefinition)
+
+  # compatibility constructor
+  def initialize(pos: Position, name: Identifier, arguments: Arguments, type: TypeName, body: NodeList, annotations: AnnotationList)
+       super(pos, name, arguments, type,  body, annotations)
+  end
+
 end
 
 class ConstructorDefinition < MethodDefinition
   init_subclass(MethodDefinition)
+
+  # compatibility constructor
+  def initialize(pos: Position, name: Identifier, arguments: Arguments, type: TypeName, body: NodeList, annotations: AnnotationList)
+       super(pos, name, arguments, type,  body, annotations)
+  end
+
 end

--- a/src/mirah/lang/ast/method.mirah
+++ b/src/mirah/lang/ast/method.mirah
@@ -84,6 +84,7 @@ class MethodDefinition < NodeImpl
     child type: TypeName
     child_list body: Node
     child_list annotations: Annotation
+    child_list modifiers: Modifier
     # exceptions
   end
 end

--- a/src/mirah/lang/ast/method.mirah
+++ b/src/mirah/lang/ast/method.mirah
@@ -77,7 +77,7 @@ class BlockArgument < NodeImpl
 end
 
 class MethodDefinition < NodeImpl
-  implements Named, Annotated
+  implements Named, Annotated, HasModifiers
   init_node do
     child name: Identifier
     child arguments: Arguments
@@ -88,37 +88,13 @@ class MethodDefinition < NodeImpl
     # exceptions
   end
 
-  # compatibility constructor
-
-  def initialize(pos: Position, name: Identifier, arguments: Arguments, type: TypeName, body: NodeList, annotations: AnnotationList)
-     super()
-     position_set pos
-     name_set name
-     arguments_set arguments
-     type_set type
-     body_set body
-     annotations_set annotations
-     modifiers_set nil
-  end
-
 end
 
 class StaticMethodDefinition < MethodDefinition
   init_subclass(MethodDefinition)
 
-  # compatibility constructor
-  def initialize(pos: Position, name: Identifier, arguments: Arguments, type: TypeName, body: NodeList, annotations: AnnotationList)
-       super(pos, name, arguments, type,  body, annotations)
-  end
-
 end
 
 class ConstructorDefinition < MethodDefinition
   init_subclass(MethodDefinition)
-
-  # compatibility constructor
-  def initialize(pos: Position, name: Identifier, arguments: Arguments, type: TypeName, body: NodeList, annotations: AnnotationList)
-       super(pos, name, arguments, type,  body, annotations)
-  end
-
 end

--- a/src/mirah/lang/ast/structure.mirah
+++ b/src/mirah/lang/ast/structure.mirah
@@ -54,3 +54,8 @@ class Annotation < NodeImpl
     child_list values: HashEntry
   end
 end
+
+
+class Modifier < NodeImpl
+    init_literal String
+end

--- a/src/mirahparser/impl/Mirah.mmeta
+++ b/src/mirahparser/impl/Mirah.mmeta
@@ -714,6 +714,7 @@ parser MirahParser {
     $ACC_VOLATILE {"VOLATILE"} |
     $ACC_NATIVE {"NATIVE"} |
     $ACC_DEFAULT {"DEFAULT"} |
+    $ACC_SYNCHRONIZED {"SYNCHRONIZED"} |
     $ACC_TRANSIENT {"TRANSIENT"}
     )
               -> ^(Modifier txt);

--- a/src/mirahparser/impl/Mirah.mmeta
+++ b/src/mirahparser/impl/Mirah.mmeta
@@ -705,13 +705,16 @@ parser MirahParser {
   annotation_list: (a=annotation opt_nl {a})*;
 
   $Returns[Node]
-  acc_modifier: txt = ($ACC_ABSTRACT {"abstract"}|
-    $ACC_PUBLIC {"public"} |
-    $ACC_PRIVATE {"private"} |
-    $ACC_PROTECTED {"protected"} |
-    $ACC_FINAL {"final"} |
-    $ACC_VOLATILE {"volatile"} |
-    $ACC_NATIVE {"native"} )
+  acc_modifier: txt = ($ACC_ABSTRACT {"ABSTRACT"}|
+    $ACC_PUBLIC {"PUBLIC"} |
+    $ACC_PRIVATE {"PRIVATE"} |
+    $ACC_PROTECTED {"PROTECTED"} |
+    $ACC_FINAL {"FINAL"} |
+    $ACC_VOLATILE {"VOLATILE"} |
+    $ACC_NATIVE {"NATIVE"} |
+    $ACC_DEFAULT {"DEFAULT"} |
+    $ACC_TRANSIENT {"TRANSIENT"}
+    )
               -> ^(Modifier txt);
 
   $Returns[List]

--- a/src/mirahparser/impl/Mirah.mmeta
+++ b/src/mirahparser/impl/Mirah.mmeta
@@ -212,6 +212,7 @@ parser MirahParser {
           | ($Def)=> primary2_def
           | ($Macro|$Defmacro)=> primary2_macro
           | ($Dollar)=> (primary2_class | primary2_interface | primary2_def | primary2_macro)
+          | (acc_modifier)=> (primary2_class | primary2_interface | primary2_def | primary2_macro)
           | ($Break)=> primary2_break
           | ($Next)=> primary2_next
           | ($Redo)=> primary2_redo
@@ -299,6 +300,7 @@ parser MirahParser {
   $Returns[Node]
   primary2_class
          : annotations=annotation_list
+           m=acc_modifier_list
            t=$Class sp=block_start(t)!
            ( $LShift! BEG e=$Self
              term! b=compstmt! verify_end(sp)! $End
@@ -309,7 +311,7 @@ parser MirahParser {
                           # sense for mirah. Maybe rescuing exceptions
                           # in the static initializer?
              verify_end(sp)! $End
-             -> ^(ClassDefinition n s b ifaces annotations)
+             -> ^(ClassDefinition n s b ifaces annotations m)
            );
   $Scope[@cond]
   $Returns[Node]
@@ -323,7 +325,7 @@ parser MirahParser {
            Do!
            b=compstmt!
            verify_end(sp) $End
-            -> ^(InterfaceDeclaration n nil b ifaces annotations)
+            -> ^(InterfaceDeclaration n nil b ifaces annotations nil)
            ;
   $Returns[Node]
   primary2_import
@@ -361,16 +363,17 @@ parser MirahParser {
   $Returns[Node]
   primary2_def
          : annotations=annotation_list
+           m=acc_modifier_list
            t=$Def s=block_start(t)!
            ( $Self! dot_or_colon! name=fname!
              arglist=f_arglist! body=bodystmt! verify_end(s)! $End
              {args = arglist.args; type=arglist.returnType}
-             -> ^(StaticMethodDefinition name args type body annotations)
+             -> ^(StaticMethodDefinition name args type body annotations m)
            | name=fname! arglist=f_arglist! body=bodystmt! verify_end(s)! $End
              {args = arglist.args; type=arglist.returnType}
              ( ?{nameIs(name, "initialize")}
-               -> ^(ConstructorDefinition name args type body annotations)
-             | -> ^(MethodDefinition name args type body annotations)
+               -> ^(ConstructorDefinition name args type body annotations m)
+             | -> ^(MethodDefinition name args type body annotations m)
              )
            );
   $Scope[@BEG]
@@ -700,6 +703,19 @@ parser MirahParser {
 
   $Returns[List]
   annotation_list: (a=annotation opt_nl {a})*;
+
+  $Returns[Node]
+  acc_modifier: txt = ($ACC_ABSTRACT {"abstract"}|
+    $ACC_PUBLIC {"public"} |
+    $ACC_PRIVATE {"private"} |
+    $ACC_PROTECTED {"protected"} |
+    $ACC_FINAL {"final"} |
+    $ACC_VOLATILE {"volatile"} |
+    $ACC_NATIVE {"native"} )
+              -> ^(Modifier txt);
+
+  $Returns[List]
+  acc_modifier_list: (a=acc_modifier {a})*;
 
   op: text=($LT {"<"}
            | $LE {"<="}

--- a/src/mirahparser/impl/Mirah.mmeta
+++ b/src/mirahparser/impl/Mirah.mmeta
@@ -640,7 +640,7 @@ parser MirahParser {
 
   $Memo[Assignment]
   lhs: (($ClassVar|$InstVar|$CONSTANT|$IDENTIFIER) $EQ)=> var_lhs
-     | ($Dollar|$Backtick|$ClassVarBacktick|$InstVarBacktick)=> (var_lhs | lhs2)
+     | ($Dollar|$Backtick|$ClassVarBacktick|$InstVarBacktick|acc_modifier)=> (var_lhs | lhs2)
   #   | ($Colons $CONSTANT)=> colon3 n=constant -> ^(ConstantAssign ^(Colon3 n))
      | lhs2;
   $Returns[Assignment]
@@ -654,9 +654,10 @@ parser MirahParser {
 
   $Returns[Assignment]
   var_lhs: ( annotations=annotation_list
-             ( ($ClassVar|$ClassVarBacktick)=> n=cvar -> ^(FieldAssign n annotations true)
-             | ($InstVar|$InstVarBacktick)=> n=ivar -> ^(FieldAssign n annotations false)
-             | ($CONSTANT)=> n=constant -> ^(ConstantAssign n nil annotations)
+             m=acc_modifier_list
+             ( ($ClassVar|$ClassVarBacktick)=> n=cvar -> ^(FieldAssign n annotations true m)
+             | ($InstVar|$InstVarBacktick)=> n=ivar -> ^(FieldAssign n annotations false m)
+             | ($CONSTANT)=> n=constant -> ^(ConstantAssign n nil annotations m)
              )
            )
          | ($IDENTIFIER)=> n=identifier -> ^(LocalAssignment n nil)

--- a/src/mirahparser/impl/MirahLexer.java
+++ b/src/mirahparser/impl/MirahLexer.java
@@ -523,7 +523,9 @@ public class MirahLexer {
         }
         break;
       case 'a':
-        if (i.consume("lias")) {
+        if (i.consume("bstract")) {
+          type = Tokens.tACC_ABSTRACT;
+        } else if (i.consume("lias")) {
           type = Tokens.tAlias;
         } else if (i.consume("nd")) {
           type = Tokens.tAnd;
@@ -578,6 +580,8 @@ public class MirahLexer {
       case 'f':
         if (i.consume("alse")) {
           type = Tokens.tFalse;
+        } else if (i.consume("inal")) {
+          type = Tokens.tACC_FINAL;
         } else if (i.consume("or")) {
           type = Tokens.tFor;
         } else {
@@ -611,6 +615,8 @@ public class MirahLexer {
       case 'n':
         if (i.consume("ext")) {
           type = Tokens.tNext;
+        } else if (i.consume("ative")) {
+          type = Tokens.tACC_NATIVE;
         } else if (i.consume("il")) {
           type = Tokens.tNil;
         } else if (i.consume("ot")) {
@@ -629,6 +635,12 @@ public class MirahLexer {
       case 'p':
         if (i.consume("ackage")) {
           type = Tokens.tPackage;
+        } else if (i.consume("rivate")) {
+          type = Tokens.tACC_PRIVATE;
+        } else if (i.consume("rotected")) {
+          type = Tokens.tACC_PROTECTED;
+        }else if (i.consume("ublic")) {
+          type = Tokens.tACC_PUBLIC;
         } else {
           type = Tokens.tIDENTIFIER;
         }
@@ -673,6 +685,13 @@ public class MirahLexer {
           type = Tokens.tUnless;
         } else if (i.consume("ntil")) {
           type = Tokens.tUntil;
+        } else {
+          type = Tokens.tIDENTIFIER;
+        }
+        break;
+      case 'v':
+        if (i.consume("olatile")) {
+          type = Tokens.tACC_VOLATILE;
         } else {
           type = Tokens.tIDENTIFIER;
         }

--- a/src/mirahparser/impl/MirahLexer.java
+++ b/src/mirahparser/impl/MirahLexer.java
@@ -667,6 +667,8 @@ public class MirahLexer {
           type = Tokens.tSelf;
         } else if (i.consume("uper")) {
           type = Tokens.tSuper;
+        } else if (i.consume("ynchronized")) {
+          type = Tokens.tACC_SYNCHRONIZED;
         } else {
           type = Tokens.tIDENTIFIER;
         }

--- a/src/mirahparser/impl/Tokens.java
+++ b/src/mirahparser/impl/Tokens.java
@@ -75,6 +75,7 @@ public enum Tokens {
   tACC_NATIVE,
   tACC_DEFAULT,
   tACC_TRANSIENT,
+  tACC_SYNCHRONIZED,
     // ClassVar must be first after the keywords, followed by other
   // identifierish tokens.
   tClassVar,

--- a/src/mirahparser/impl/Tokens.java
+++ b/src/mirahparser/impl/Tokens.java
@@ -73,6 +73,8 @@ public enum Tokens {
   tACC_FINAL,
   tACC_VOLATILE,
   tACC_NATIVE,
+  tACC_DEFAULT,
+  tACC_TRANSIENT,
     // ClassVar must be first after the keywords, followed by other
   // identifierish tokens.
   tClassVar,

--- a/src/mirahparser/impl/Tokens.java
+++ b/src/mirahparser/impl/Tokens.java
@@ -66,7 +66,14 @@ public enum Tokens {
   tWhen,
   tWhile,
   tYield,
-  // ClassVar must be first after the keywords, followed by other
+  tACC_ABSTRACT,
+  tACC_PUBLIC,
+  tACC_PRIVATE,
+  tACC_PROTECTED,
+  tACC_FINAL,
+  tACC_VOLATILE,
+  tACC_NATIVE,
+    // ClassVar must be first after the keywords, followed by other
   // identifierish tokens.
   tClassVar,
   tInstVar,

--- a/test/test_mirah.rb
+++ b/test/test_mirah.rb
@@ -368,6 +368,9 @@ EOF
                  "abstract def +; 1; end")
     assert_parse("[Script, [[StaticMethodDefinition, [SimpleString, puts], [Arguments, [RequiredArgumentList], [OptionalArgumentList], null, [RequiredArgumentList], null], null, [], [AnnotationList], [ModifierList, [Modifier:FINAL], [Modifier:PROTECTED]]]]]",
                  "final protected def self.puts; end")
+    assert_parse("[Script, [[ConstantAssign, [SimpleString, A], [VCall, [SimpleString, b]], [AnnotationList], [ModifierList, [Modifier:FINAL]]]]]", "final A = b")
+    assert_parse("[Script, [[FieldAssign, [SimpleString, a], [VCall, [SimpleString, b]], [AnnotationList], [ModifierList, [Modifier:PROTECTED]]]]]", "protected @a = b")
+    assert_parse("[Script, [[FieldAssign, [SimpleString, a], [VCall, [SimpleString, b]], [AnnotationList], [ModifierList, [Modifier:FINAL], [Modifier:TRANSIENT]], static]]]", "final transient @@a = b")
     assert_fails("abstract")
     assert_fails("def abstract;end")
     assert_fails("self.abstract")
@@ -568,9 +571,9 @@ EOF
 
   def test_lhs
     assert_parse("[Script, [[LocalAssignment, [SimpleString, a], [VCall, [SimpleString, b]]]]]", "a = b")
-    assert_parse("[Script, [[ConstantAssign, [SimpleString, A], [VCall, [SimpleString, b]], [AnnotationList]]]]", "A = b")
-    assert_parse("[Script, [[FieldAssign, [SimpleString, a], [VCall, [SimpleString, b]], [AnnotationList]]]]", "@a = b")
-    assert_parse("[Script, [[FieldAssign, [SimpleString, a], [VCall, [SimpleString, b]], [AnnotationList], static]]]", "@@a = b")
+    assert_parse("[Script, [[ConstantAssign, [SimpleString, A], [VCall, [SimpleString, b]], [AnnotationList], [ModifierList]]]]", "A = b")
+    assert_parse("[Script, [[FieldAssign, [SimpleString, a], [VCall, [SimpleString, b]], [AnnotationList], [ModifierList]]]]", "@a = b")
+    assert_parse("[Script, [[FieldAssign, [SimpleString, a], [VCall, [SimpleString, b]], [AnnotationList], [ModifierList], static]]]", "@@a = b")
     assert_parse("[Script, [[ElemAssign, [VCall, [SimpleString, a]], [[Fixnum, 0]], [VCall, [SimpleString, b]]]]]", "a[0] = b")
     assert_parse("[Script, [[AttrAssign, [VCall, [SimpleString, a]], [SimpleString, foo], [VCall, [SimpleString, b]]]]]", "a.foo = b")
     assert_parse("[Script, [[AttrAssign, [VCall, [SimpleString, a]], [SimpleString, foo], [VCall, [SimpleString, b]]]]]", "a::foo = b")
@@ -585,7 +588,7 @@ EOF
                  "a &&= b")
     assert_parse("[Script, [[If, [LocalAccess, [SimpleString, a]], [[LocalAccess, [SimpleString, a]]], [[LocalAssignment, [SimpleString, a], [VCall, [SimpleString, b]]]]]]]",
                  "a ||= b")
-    assert_parse("[Script, [[FieldAssign, [SimpleString, a], [Call, [FieldAccess, [SimpleString, a]], [SimpleString, +], [[Fixnum, 1]], null], [AnnotationList]]]]",
+    assert_parse("[Script, [[FieldAssign, [SimpleString, a], [Call, [FieldAccess, [SimpleString, a]], [SimpleString, +], [[Fixnum, 1]], null], [AnnotationList], [ModifierList]]]]",
                  "@a += 1")
     assert_parse("[Script, [[[LocalAssignment, [SimpleString, $ptemp$1], [VCall, [SimpleString, a]]]," +
                                 " [LocalAssignment, [SimpleString, $ptemp$2], [Fixnum, 1]]," +
@@ -711,7 +714,7 @@ EOF
     assert_parse("[Script, [[Call, [VCall, [SimpleString, a]], [Unquote, [VCall, [SimpleString, foo]]], [], null]]]", 'a.`foo`')
     assert_parse("[Script, [[Call, [Self], [Unquote, [VCall, [SimpleString, foo]]], [], null]]]", 'self.`foo`')
     assert_parse("[Script, [[FieldAccess, [Unquote, [VCall, [SimpleString, a]]]]]]", "@`a`")
-    assert_parse("[Script, [[FieldAssign, [Unquote, [VCall, [SimpleString, a]]], [Fixnum, 1], [AnnotationList]]]]", "@`a` = 1")
+    assert_parse("[Script, [[FieldAssign, [Unquote, [VCall, [SimpleString, a]]], [Fixnum, 1], [AnnotationList], [ModifierList]]]]", "@`a` = 1")
     assert_parse("[Script, [[UnquoteAssign, [Unquote, [VCall, [SimpleString, a]]], [VCall, [SimpleString, b]]]]]", "`a` = b")
     assert_parse("[Script, [[MacroDefinition, [SimpleString, foo], null," +
                                                " [[FunctionalCall, [SimpleString, quote], [], [Block, null, [[VCall, [SimpleString, bar]]]]]], [AnnotationList]]]]",
@@ -726,12 +729,12 @@ EOF
    end
 
    def test_annotation
-     assert_parse("[Script, [[FieldAssign, [SimpleString, a], [Fixnum, 1], [AnnotationList, [Annotation, [Constant, [SimpleString, Foo]], [HashEntryList]]]]]]", "$Foo @a = 1")
-     assert_parse("[Script, [[FieldAssign, [SimpleString, a], [Fixnum, 1], [AnnotationList, [Annotation, [Constant, [SimpleString, Foo]], [HashEntryList, [HashEntry, [SimpleString, value], [Constant, [SimpleString, Bar]]]]]]]]]", "$Foo[Bar] @a = 1")
-     assert_parse("[Script, [[FieldAssign, [SimpleString, a], [Fixnum, 1], [AnnotationList, [Annotation, [Constant, [SimpleString, Foo]], [HashEntryList, [HashEntry, [SimpleString, foo], [Constant, [SimpleString, Bar]]]]]]]]]", "$Foo[foo: Bar] @a = 1")
-     assert_parse("[Script, [[FieldAssign, [SimpleString, a], [Fixnum, 1], [AnnotationList, [Annotation, [Colon2, [Constant, [SimpleString, foo]], [Constant, [SimpleString, Bar]]], [HashEntryList]]]]]]", "$foo.Bar @a = 1")
-     assert_parse("[Script, [[FieldAssign, [SimpleString, a], [Fixnum, 1], [AnnotationList, [Annotation, [Colon2, [Constant, [SimpleString, foo]], [Constant, [SimpleString, Bar]]], [HashEntryList]]]]]]", "$foo::Bar @a = 1")
-     assert_parse("[Script, [[FieldAssign, [SimpleString, a], [Fixnum, 1], [AnnotationList, [Annotation, [Constant, [SimpleString, Foo]], [HashEntryList, [HashEntry, [SimpleString, value], [Array, [[Constant, [SimpleString, Bar]], [Constant, [SimpleString, Baz]]]]]]]]]]]", "$Foo[Bar, Baz] @a = 1")
+     assert_parse("[Script, [[FieldAssign, [SimpleString, a], [Fixnum, 1], [AnnotationList, [Annotation, [Constant, [SimpleString, Foo]], [HashEntryList]]], [ModifierList]]]]", "$Foo @a = 1")
+     assert_parse("[Script, [[FieldAssign, [SimpleString, a], [Fixnum, 1], [AnnotationList, [Annotation, [Constant, [SimpleString, Foo]], [HashEntryList, [HashEntry, [SimpleString, value], [Constant, [SimpleString, Bar]]]]]], [ModifierList]]]]", "$Foo[Bar] @a = 1")
+     assert_parse("[Script, [[FieldAssign, [SimpleString, a], [Fixnum, 1], [AnnotationList, [Annotation, [Constant, [SimpleString, Foo]], [HashEntryList, [HashEntry, [SimpleString, foo], [Constant, [SimpleString, Bar]]]]]], [ModifierList]]]]", "$Foo[foo: Bar] @a = 1")
+     assert_parse("[Script, [[FieldAssign, [SimpleString, a], [Fixnum, 1], [AnnotationList, [Annotation, [Colon2, [Constant, [SimpleString, foo]], [Constant, [SimpleString, Bar]]], [HashEntryList]]], [ModifierList]]]]", "$foo.Bar @a = 1")
+     assert_parse("[Script, [[FieldAssign, [SimpleString, a], [Fixnum, 1], [AnnotationList, [Annotation, [Colon2, [Constant, [SimpleString, foo]], [Constant, [SimpleString, Bar]]], [HashEntryList]]], [ModifierList]]]]", "$foo::Bar @a = 1")
+     assert_parse("[Script, [[FieldAssign, [SimpleString, a], [Fixnum, 1], [AnnotationList, [Annotation, [Constant, [SimpleString, Foo]], [HashEntryList, [HashEntry, [SimpleString, value], [Array, [[Constant, [SimpleString, Bar]], [Constant, [SimpleString, Baz]]]]]]]], [ModifierList]]]]", "$Foo[Bar, Baz] @a = 1")
    end
 
    def test_return

--- a/test/test_mirah.rb
+++ b/test/test_mirah.rb
@@ -368,6 +368,8 @@ EOF
                  "abstract def +; 1; end")
     assert_parse("[Script, [[StaticMethodDefinition, [SimpleString, puts], [Arguments, [RequiredArgumentList], [OptionalArgumentList], null, [RequiredArgumentList], null], null, [], [AnnotationList], [ModifierList, [Modifier:FINAL], [Modifier:PROTECTED]]]]]",
                  "final protected def self.puts; end")
+    assert_parse("[Script, [[StaticMethodDefinition, [SimpleString, puts], [Arguments, [RequiredArgumentList], [OptionalArgumentList], null, [RequiredArgumentList], null], null, [], [AnnotationList], [ModifierList, [Modifier:FINAL], [Modifier:SYNCHRONIZED]]]]]",
+                 "final synchronized def self.puts; end")
     assert_parse("[Script, [[ConstantAssign, [SimpleString, A], [VCall, [SimpleString, b]], [AnnotationList], [ModifierList, [Modifier:FINAL]]]]]", "final A = b")
     assert_parse("[Script, [[FieldAssign, [SimpleString, a], [VCall, [SimpleString, b]], [AnnotationList], [ModifierList, [Modifier:PROTECTED]]]]]", "protected @a = b")
     assert_parse("[Script, [[FieldAssign, [SimpleString, a], [VCall, [SimpleString, b]], [AnnotationList], [ModifierList, [Modifier:FINAL], [Modifier:TRANSIENT]], static]]]", "final transient @@a = b")

--- a/test/test_mirah.rb
+++ b/test/test_mirah.rb
@@ -360,13 +360,13 @@ EOF
   end
 
   def test_modifiers
-    assert_parse("[Script, [[ClassDefinition, [Constant, [SimpleString, A]], null, [], [TypeNameList], [AnnotationList, [Annotation, [Constant, [SimpleString, T]], [HashEntryList]]], [ModifierList, [Modifier:abstract]]]]]", "$T\nabstract class A;end")
-    assert_parse("[Script, [[ClassDefinition, [Constant, [SimpleString, A]], null, [], [TypeNameList], [AnnotationList], [ModifierList, [Modifier:abstract]]]]]", "abstract class A;end")
-    assert_parse("[Script, [[ClassDefinition, [Constant, [SimpleString, A]], null, [], [TypeNameList], [AnnotationList], [ModifierList, [Modifier:abstract], [Modifier:private]]]]]", "abstract private class A;end")
-    assert_parse("[Script, [[ClassDefinition, [Constant, [SimpleString, A]], null, [], [TypeNameList], [AnnotationList], [ModifierList, [Modifier:final], [Modifier:abstract], [Modifier:private]]]]]", "final abstract private class A;end")
-    assert_parse("[Script, [[MethodDefinition, [SimpleString, +], [Arguments, [RequiredArgumentList], [OptionalArgumentList], null, [RequiredArgumentList], null], null, [[Fixnum, 1]], [AnnotationList], [ModifierList, [Modifier:abstract]]]]]",
+    assert_parse("[Script, [[ClassDefinition, [Constant, [SimpleString, A]], null, [], [TypeNameList], [AnnotationList, [Annotation, [Constant, [SimpleString, T]], [HashEntryList]]], [ModifierList, [Modifier:ABSTRACT]]]]]", "$T\nabstract class A;end")
+    assert_parse("[Script, [[ClassDefinition, [Constant, [SimpleString, A]], null, [], [TypeNameList], [AnnotationList], [ModifierList, [Modifier:ABSTRACT]]]]]", "abstract class A;end")
+    assert_parse("[Script, [[ClassDefinition, [Constant, [SimpleString, A]], null, [], [TypeNameList], [AnnotationList], [ModifierList, [Modifier:ABSTRACT], [Modifier:PRIVATE]]]]]", "abstract private class A;end")
+    assert_parse("[Script, [[ClassDefinition, [Constant, [SimpleString, A]], null, [], [TypeNameList], [AnnotationList], [ModifierList, [Modifier:FINAL], [Modifier:ABSTRACT], [Modifier:PRIVATE]]]]]", "final abstract private class A;end")
+    assert_parse("[Script, [[MethodDefinition, [SimpleString, +], [Arguments, [RequiredArgumentList], [OptionalArgumentList], null, [RequiredArgumentList], null], null, [[Fixnum, 1]], [AnnotationList], [ModifierList, [Modifier:ABSTRACT]]]]]",
                  "abstract def +; 1; end")
-    assert_parse("[Script, [[StaticMethodDefinition, [SimpleString, puts], [Arguments, [RequiredArgumentList], [OptionalArgumentList], null, [RequiredArgumentList], null], null, [], [AnnotationList], [ModifierList, [Modifier:final], [Modifier:protected]]]]]",
+    assert_parse("[Script, [[StaticMethodDefinition, [SimpleString, puts], [Arguments, [RequiredArgumentList], [OptionalArgumentList], null, [RequiredArgumentList], null], null, [], [AnnotationList], [ModifierList, [Modifier:FINAL], [Modifier:PROTECTED]]]]]",
                  "final protected def self.puts; end")
     assert_fails("abstract")
     assert_fails("def abstract;end")


### PR DESCRIPTION
This commit adds most of Opcode.ACC_* modifiers as keywords:
  abstract,
  public,
  private,
  protected,
  final,
  volatile,
  native,
  default,
  transient,
  synchronized

Note that super, static, annotations and others are implemented in other syntax constructs in mirah.
This change brake compatibility in https://github.com/mirah/mirah language. 
Support for new modifiers added in https://github.com/uujava/mirah. 