### PR TITLE
support for unsigned right shift operator

### DIFF
--- a/src/mirahparser/impl/Mirah.mmeta
+++ b/src/mirahparser/impl/Mirah.mmeta
@@ -708,7 +708,7 @@ parser MirahParser {
            | $GT {">"}
            | $GE {">="}
            | $LShift {"<<"}
-           | $LLShift {"<<<"}
+           | $RRShift {">>>"}
            | $RShift {">>"}
            | $Bang {"!"}
            | $NE {"!="}

--- a/src/mirahparser/impl/MirahLexer.java
+++ b/src/mirahparser/impl/MirahLexer.java
@@ -799,8 +799,6 @@ public class MirahLexer {
           if (i.consume('<')) {
             if (i.consume('=')) {
               type = Tokens.tOpAssign;
-            } else {
-              type = Tokens.tLLShift;
             }
           } else if (i.consume('=')) {
             type = Tokens.tOpAssign;
@@ -818,7 +816,11 @@ public class MirahLexer {
           if (i.consume('=')) {
             type = Tokens.tOpAssign;
           } else {
-            type = Tokens.tRShift;
+              if(i.consume('>')) {
+                  type = Tokens.tRRShift;
+              }else {
+                  type = Tokens.tRShift;
+              }
           }
         } else {
           type = Tokens.tGT;

--- a/src/mirahparser/impl/Tokens.java
+++ b/src/mirahparser/impl/Tokens.java
@@ -108,7 +108,7 @@ public enum Tokens {
   tEEQ,
   tEEEQ,
   tLShift,
-  tLLShift,
+  tRRShift,
   tRShift,
   tEQ,
   tAndEq,

--- a/test/test_mirah.rb
+++ b/test/test_mirah.rb
@@ -460,7 +460,7 @@ EOF
 
   def test_def
     names = %w(foo bar? baz! def= rescue Class & | ^ < > + - * / % ! ~ <=> ==
-               === =~ !~ <= >= << <<< >> != ** []= [] +@ -@)
+               === =~ !~ <= >= << >>> >> != ** []= [] +@ -@)
     names.each do |name|
       assert_parse("[Script, [[MethodDefinition, [SimpleString, #{name}], [Arguments, [RequiredArgumentList], [OptionalArgumentList], null, [RequiredArgumentList], null], null, [[Fixnum, 1]], [AnnotationList]]]]",
                    "def #{name}; 1; end")


### PR DESCRIPTION
We need mirah support for java unsigned right shift (>>>). 
There was <<< operator in mirah-parser. Guess it's typo as it's this is not supported in java nor ruby. 
(<<<) removed from mirah-parser, >>> implemented in this pull request. 